### PR TITLE
The mediator pattern implementation

### DIFF
--- a/grade/internal/infrastructure/seedwork/mediator/mediator.go
+++ b/grade/internal/infrastructure/seedwork/mediator/mediator.go
@@ -1,4 +1,0 @@
-package mediator
-
-type MediatorImp struct {
-}

--- a/grade/internal/infrastructure/seedwork/mediator/untyped.go
+++ b/grade/internal/infrastructure/seedwork/mediator/untyped.go
@@ -1,0 +1,146 @@
+package mediator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+
+	"github.com/emacsway/grade/grade/internal/domain/seedwork/disposable"
+	"github.com/hashicorp/go-multierror"
+)
+
+var (
+	ErrUnsuitableHandlerSignature = errors.New("passed handler has unsuitable signature")
+)
+
+type Handler func(ctx context.Context, command any) (any, error)
+
+func AsUntyped[T any](handler func(ctx context.Context, command T) (any, error)) Handler {
+	return func(ctx context.Context, command any) (any, error) {
+		if typedCommand, ok := command.(T); ok {
+			return handler(ctx, typedCommand)
+		}
+
+		return nil, ErrUnsuitableHandlerSignature
+	}
+}
+
+type RefUntypedMediator struct {
+	hLock    sync.RWMutex
+	handlers map[reflect.Type]Handler
+
+	sLock       sync.RWMutex
+	subscribers map[reflect.Type]map[reflect.Value]Handler
+
+	pLock sync.RWMutex
+	pipes []func(next Handler) Handler
+}
+
+func NewRefUntypedMediator() *RefUntypedMediator {
+	return &RefUntypedMediator{
+		hLock:    sync.RWMutex{},
+		handlers: map[reflect.Type]Handler{},
+
+		sLock:       sync.RWMutex{},
+		subscribers: map[reflect.Type]map[reflect.Value]Handler{},
+
+		pLock: sync.RWMutex{},
+	}
+}
+
+func (m *RefUntypedMediator) AddPipe(pipe func(next Handler) Handler) {
+	m.pLock.Lock()
+	defer m.pLock.Unlock()
+
+	m.pipes = append(m.pipes, pipe)
+}
+
+func (m *RefUntypedMediator) executeWithPipeline(handler Handler, ctx context.Context, command any) (any, error) {
+	m.pLock.RLock()
+	defer m.pLock.RUnlock()
+
+	current := func(ctx context.Context, command any) (any, error) {
+		return handler(ctx, command)
+	}
+
+	for ixd := range m.pipes {
+		reverse := len(m.pipes) - 1 - ixd
+		current = m.pipes[reverse](current)
+	}
+
+	return current(ctx, command)
+}
+
+func (m *RefUntypedMediator) Send(ctx context.Context, command any) (any, error) {
+	m.hLock.RLock()
+	defer m.hLock.RUnlock()
+
+	commandType := reflect.TypeOf(command)
+	if handler, found := m.handlers[commandType]; found {
+		return m.executeWithPipeline(handler, ctx, command)
+	}
+
+	return nil, nil
+}
+
+func (m *RefUntypedMediator) Register(command any, handler Handler) disposable.Disposable {
+	m.hLock.Lock()
+	defer m.hLock.Unlock()
+
+	commandType := reflect.TypeOf(command)
+	m.handlers[commandType] = handler
+
+	return disposable.NewDisposable(func() {
+		m.Unregister(command)
+	})
+}
+
+func (m *RefUntypedMediator) Unregister(command any) {
+	m.hLock.Lock()
+	defer m.hLock.Unlock()
+
+	commandType := reflect.TypeOf(command)
+	delete(m.handlers, commandType)
+}
+
+func (m *RefUntypedMediator) Subscribe(event any, handler Handler) disposable.Disposable {
+	m.sLock.Lock()
+	defer m.sLock.Unlock()
+
+	valueType := reflect.TypeOf(event)
+	if _, found := m.subscribers[valueType]; !found {
+		m.subscribers[valueType] = map[reflect.Value]Handler{}
+	}
+
+	handlerValue := reflect.ValueOf(handler)
+	m.subscribers[valueType][handlerValue] = handler
+
+	return disposable.NewDisposable(func() {
+		m.Unsubscribe(event, handler)
+	})
+}
+
+func (m *RefUntypedMediator) Unsubscribe(event any, handler Handler) {
+	m.sLock.Lock()
+	defer m.sLock.Unlock()
+
+	eventType := reflect.TypeOf(event)
+	handlerValue := reflect.ValueOf(handler)
+
+	delete(m.subscribers[eventType], handlerValue)
+}
+
+func (m *RefUntypedMediator) Publish(ctx context.Context, event any) error {
+	m.sLock.RLock()
+	defer m.sLock.RUnlock()
+
+	var errs error
+	eventType := reflect.TypeOf(event)
+	for _, handler := range m.subscribers[eventType] {
+		_, err := handler(ctx, event)
+		errs = multierror.Append(errs, err)
+	}
+
+	return errs
+}

--- a/grade/internal/infrastructure/seedwork/mediator/untyped_test.go
+++ b/grade/internal/infrastructure/seedwork/mediator/untyped_test.go
@@ -1,0 +1,270 @@
+package mediator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+)
+
+type (
+	Event struct {
+		name string
+	}
+	Command struct {
+		name string
+	}
+)
+
+func TestMediator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+
+		assertion func(t *testing.T, m *RefUntypedMediator)
+	}{
+		{
+			name: "test_publish",
+
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				counter := 0
+				handler := func(ctx context.Context, t any) (any, error) {
+					counter++
+
+					return nil, nil
+				}
+
+				m.Subscribe(Event{}, handler)
+
+				_ = m.Publish(context.Background(), Event{})
+				assert.Equal(t, 1, counter)
+			},
+		},
+
+		{
+			name: "test_unsubscribe",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+
+				times := 0
+				handler := func(ctx context.Context, e any) (any, error) {
+					times++
+					return nil, nil
+				}
+
+				times2 := 0
+				handler2 := func(ctx context.Context, e any) (any, error) {
+					times2++
+					return nil, nil
+				}
+
+				times3 := 0
+				handler3 := AsUntyped(func(ctx context.Context, e any) (any, error) {
+					times3++
+					return nil, nil
+				})
+
+				m.Subscribe(Event{}, handler)
+				m.Subscribe(Event{}, handler2)
+				m.Subscribe(Event{}, handler3)
+
+				m.Unsubscribe(Event{}, handler)
+				_ = m.Publish(context.Background(), Event{})
+
+				assert.Equal(t, 0, times)
+				assert.Equal(t, 1, times2)
+				assert.Equal(t, 1, times3)
+
+				m.Unsubscribe(Event{}, handler3)
+				_ = m.Publish(context.Background(), Event{})
+
+				assert.Equal(t, 0, times)
+				assert.Equal(t, 2, times2)
+				assert.Equal(t, 1, times3)
+			},
+		},
+
+		{
+			name: "test_disposable_event",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+
+				times := 0
+				handler := func(ctx context.Context, e any) (any, error) {
+					times++
+					return nil, nil
+				}
+
+				times2 := 0
+				handler2 := func(ctx context.Context, e any) (any, error) {
+					times2++
+					return nil, nil
+				}
+
+				disposable := m.Subscribe(Event{}, handler)
+				m.Subscribe(Event{}, handler2)
+
+				disposable.Dispose()
+				_ = m.Publish(context.Background(), Event{})
+
+				assert.Equal(t, 0, times)
+				assert.Equal(t, 1, times2)
+			},
+		},
+
+		{
+			name: "test_send",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				times := 0
+				handler := func(ctx context.Context, e any) (any, error) {
+					times++
+					return nil, nil
+				}
+
+				m.Register(Command{}, handler)
+				_, _ = m.Send(context.Background(), Command{})
+
+				assert.Equal(t, 1, times)
+			},
+		},
+
+		{
+			name: "test_unregister",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				times := 0
+				handler := func(ctx context.Context, e any) (any, error) {
+					times++
+
+					return nil, nil
+				}
+
+				m.Register(Command{}, handler)
+				m.Unregister(Command{})
+
+				_, _ = m.Send(context.Background(), Command{})
+
+				assert.Equal(t, 0, times)
+			},
+		},
+
+		{
+			name: "test_disposable_command",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				times := 0
+				handler := func(ctx context.Context, e any) (any, error) {
+					times++
+
+					return nil, nil
+				}
+
+				disposable := m.Register(Command{}, handler)
+				disposable.Dispose()
+
+				_, _ = m.Send(context.Background(), Command{})
+
+				assert.Equal(t, 0, times)
+			},
+		},
+
+		{
+			name: "test_unsuitable_params_type_handler",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				times := 0
+				handler := func(ctx context.Context, e int) (any, error) {
+					times++
+
+					return nil, nil
+				}
+
+				m.Register(Command{}, AsUntyped(handler))
+
+				_, err := m.Send(context.Background(), Command{})
+				assert.Equal(t, ErrUnsuitableHandlerSignature, err)
+			},
+		},
+
+		{
+			name: "test_returning_errors",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+				handlerError := errors.New("")
+
+				handler := func(ctx context.Context, e any) (any, error) {
+					return nil, handlerError
+				}
+
+				handler2 := func(ctx context.Context, e any) (any, error) {
+					return nil, handlerError
+				}
+
+				handler3 := func(ctx context.Context, e Event) (any, error) {
+					return nil, handlerError
+				}
+
+				m.Register(Command{}, handler)
+
+				m.Subscribe(Event{}, handler2)
+				m.Subscribe(Event{}, AsUntyped(handler3))
+
+				var errs error
+				errs = multierror.Append(errs, handlerError, handlerError)
+				assert.Equal(t, errs, m.Publish(context.Background(), Event{}))
+
+				_, err := m.Send(context.Background(), Command{})
+				assert.Equal(t, handlerError, err)
+			},
+		},
+		{
+			name: "test_execute_pipeline",
+			assertion: func(t *testing.T, m *RefUntypedMediator) {
+
+				m.AddPipe(func(next Handler) Handler {
+
+					return AsUntyped[Command](func(ctx context.Context, command Command) (any, error) {
+						return next(ctx, Command{name: command.name + "1"})
+					})
+
+				})
+
+				m.AddPipe(func(next Handler) Handler {
+
+					return AsUntyped[Command](func(ctx context.Context, command Command) (any, error) {
+						return next(ctx, Command{name: command.name + "2"})
+					})
+
+				})
+
+				handler := func(ctx context.Context, e any) (any, error) {
+					command := e.(Command)
+					return Command{name: command.name + "3"}, nil
+				}
+
+				m.Register(Command{}, handler)
+
+				res, err := m.Send(context.Background(), Command{})
+				assert.NoError(t, err)
+
+				assert.Equal(t, Command{name: "123"}, res)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewRefUntypedMediator()
+			tt.assertion(t, m)
+		})
+	}
+}
+
+func asd() {
+	m := NewRefUntypedMediator()
+
+	handler3 := func(ctx context.Context, e Event) (any, error) {
+		return nil, nil
+	}
+
+	m.Subscribe(Event{}, AsUntyped(handler3))
+}


### PR DESCRIPTION
Сделал две реализации:

Подобно проекту https://github.com/mehdihadeli/Go-MediatR/. В нем мне не понравилось, что там публикация событий которые не возвращают ошибок выделяется в набор отдельных методов `NotificationHandlers` и так же есть такой же набор для обработчиков которые возвращают результат в сигнатуре и два разных метода на отправку событий. Как по мне переусложнили решение. Но такое решение благодаря джереникам позволяет отлавливать ошибки на этапе компиляции, но ему присущи все +/- глобального доступа.  К тому же сейчас глобальная версия использует локи, это вызовет замедление при нагрузке, но там можно будте заменить на подобное https://github.com/orcaman/concurrent-map

Второе решение проверяет сигнатуры только в рантайме, это довольно печально. Ибо нельзя подкидывать разные джерики для метов с одинаковым ресивером.  Можно совместить техники из двух вариантов и получить что-то подобное:

```go
var m = NewRefUntypedMediator()

func strictSend[E any](m RefUntypedMediator, ctx context.Context,  event E) error  {
	return m.Send(ctx, event)
}
```

